### PR TITLE
Remove unnecessary use of class_eval; improve test output

### DIFF
--- a/lib/ar/timestamptz.rb
+++ b/lib/ar/timestamptz.rb
@@ -3,13 +3,13 @@
 require "active_record"
 require "active_record/connection_adapters/postgresql_adapter"
 
-ActiveRecord::Type.class_eval do
-  extension = Module.new do
+module AR
+  module Timestamptz
     def column(name, type, **options)
       type = :timestamptz if type == :datetime
       super(name, type, **options)
     end
   end
-
-  ActiveRecord::ConnectionAdapters::TableDefinition.prepend(extension)
 end
+
+ActiveRecord::ConnectionAdapters::TableDefinition.prepend(AR::Timestamptz)

--- a/test/ar/timestamptz_test.rb
+++ b/test/ar/timestamptz_test.rb
@@ -15,8 +15,8 @@ class TimestamptzTest < Minitest::Test
     end
 
     columns = model.columns.reject {|col| col.name == "id" }
-    all_timestamptz = columns.all? {|col| col.sql_type == "timestamp with time zone" }
-
-    assert all_timestamptz
+    columns.each do |col|
+      assert_equal "timestamp with time zone", col.sql_type, col.name
+    end
   end
 end


### PR DESCRIPTION
We noticed the recent change was using `class_eval` when it doesn't seem necessary. This also modifies the test output to better indicate which column is failing the test.