### PR TITLE
Remove #columns override; update tests

### DIFF
--- a/lib/ar/timestamptz.rb
+++ b/lib/ar/timestamptz.rb
@@ -3,13 +3,4 @@
 require "active_record"
 require "active_record/connection_adapters/postgresql_adapter"
 
-ActiveRecord::Type.class_eval do
-  extension = Module.new do
-    def column(name, type, **options)
-      type = :timestamptz if type == :datetime
-      super(name, type, **options)
-    end
-  end
-
-  ActiveRecord::ConnectionAdapters::TableDefinition.prepend(extension)
-end
+ActiveRecord::ConnectionAdapters::PostgreSQLAdapter::NATIVE_DATABASE_TYPES[:datetime] = {name: "timestamptz"}

--- a/test/ar/timestamptz_test.rb
+++ b/test/ar/timestamptz_test.rb
@@ -15,8 +15,8 @@ class TimestamptzTest < Minitest::Test
     end
 
     columns = model.columns.reject {|col| col.name == "id" }
-    all_timestamptz = columns.all? {|col| col.sql_type == "timestamp with time zone" }
-
-    assert all_timestamptz
+    columns.each do |col|
+      assert_match %r{timestamp(:?\(\d\))? with time zone}, col.sql_type, col.name
+    end
   end
 end


### PR DESCRIPTION
In Rails 6, the previous implementation modifying NATIVE_DATABASE_TYPES still works, but runs into test failures because the created_at and updated_at columns are created with a set precision of 6.

This returns to the original implementation and updates the tests to pass when given a sql type with a specified precision, which looks like `timestamp(6) with time zone`.

This seems like a better solution than what I added in #1, so I'm closing that PR.